### PR TITLE
Combined top level app data to a single structure

### DIFF
--- a/ToasterScout/app/MatchSetup.js
+++ b/ToasterScout/app/MatchSetup.js
@@ -3,23 +3,22 @@ import { Text, StyleSheet, View, ScrollView, Modal, Pressable, TextInput } from 
 
 
 const MatchSetup = ({
-  currentScoutName, 
-  currentMatchNumber,
-  onScoutNameChange, 
-  onMatchChange
+  appData,
+  setAppData
 }) => {
 
-  const [displayScoutName, setDisplayScoutName] = useState(currentScoutName);
-  const [displayMatchNumber, setDisplayMatchNumber] = useState(currentMatchNumber);
+  const [displayScoutName, setDisplayScoutName] = useState(appData.currentScout);
+  const [displayMatchNumber, setDisplayMatchNumber] = useState(appData.currentMatch);
 
   const [modalVisible, setModalVisible] = useState(false);
-  const [newScoutName, setNewScoutName] = React.useState(currentScoutName);
+  const [newScoutName, setNewScoutName] = useState(displayScoutName);
 
   // *** Process Scout Name changes ***
   const onUpdateScoutName = (action) => {
     if (action == 'save') {
       // Update the Scout Name for the application
-      onScoutNameChange(newScoutName);
+      //onScoutNameChange(newScoutName);
+      setAppData(prevAppData => ({...prevAppData, currentScout: newScoutName}));
       // update the scout name for this view
       setDisplayScoutName(newScoutName);
     }
@@ -32,7 +31,7 @@ const MatchSetup = ({
   
   // TODO: need move this data to match Add / Inport in the settings view
   const matchs = [
-    {matchId: "2024milac_qm1", matchNumber: 1,  teamNumber: 3641, matchStatus: 0},
+    {matchId: "2024milac_qm1", matchNumber: 1,  teamNumber: 3641, matchStatus: 1},
     {matchId: "2024milac_qm2", matchNumber: 2,  teamNumber: 1711, matchStatus: 0},
     {matchId: "2024milac_qm3", matchNumber: 3,  teamNumber: 1918, matchStatus: 0},
     {matchId: "2024milac_qm4", matchNumber: 4,  teamNumber: 5505, matchStatus: 0},
@@ -140,8 +139,12 @@ const MatchSetup = ({
             {matchs.map(value => (
               <Pressable
               key={value.matchId}
-              onPress={() => {console.log('Match: ' + value.matchNumber +  ` selected`); onMatchChange(value.matchNumber, value.teamNumber); setDisplayMatchNumber(value.matchNumber);}}
-              style={[styles.matchButton, displayMatchNumber === value.matchNumber && styles.matchSelected]}>
+              onPress={() => {console.log('Match: ' + value.matchNumber +  ` selected`); 
+                              setAppData(prevAppData => ({...prevAppData, currentMatch: value.matchNumber, currentTeam: value.teamNumber}));
+                              // setAppData({...appData, currentTeam: value.teamNumber});
+                              // onMatchChange(value.matchNumber, value.teamNumber); 
+                              setDisplayMatchNumber(value.matchNumber);}}
+              style={[styles.matchButton, value.matchStatus == 1 && styles.matchSaved, displayMatchNumber === value.matchNumber && styles.matchSelected]}>
               <Text style={[styles.buttonLabel]}>{value.matchNumber}{"\n"}{value.teamNumber}</Text>
             </Pressable>
             ))}
@@ -221,6 +224,10 @@ const styles = StyleSheet.create({
     backgroundColor: 'coral',
     borderWidth: 0,
   },
+  matchSaved: {
+    backgroundColor: 'green',
+    borderWidth: 0,
+  },
   buttonLabel: {
     fontSize: 22,
     fontWeight: '500',
@@ -254,7 +261,7 @@ const styles = StyleSheet.create({
     fontSize: 22,
   },
   input: {
-    height: 40,
+    height: 45,
     minWidth: '40%',
     margin: 12,
     borderWidth: 1,

--- a/ToasterScout/app/index.js
+++ b/ToasterScout/app/index.js
@@ -12,11 +12,9 @@ import AppSettings from "@/app/AppSettings";
 
 export default function App() {
   
-  const [selectedContent, setSelectedContent] = useState('MatchSelect');
-  const [scoutLocation, setScoutLocation] = useState('Blue 1'); // Info from the Setup view screen in future release
-  const [scoutName, setScoutName] = useState('JacobK'); // Info from the Match Selectvview in future release
-  const [currentTeam, setCurrentTeam] = useState(3641); // Info from the Match Selectvview in future release
-  const [matchNumber, setMatchNumber] = useState(1); // Info from the Match Selectvview in future release
+  // Info from the Setup view screen in future release
+  const [appData, setAppData] = useState({scountLocation: 'Red 1', currentScout: 'JacobK', currentTeam: 3641, currentMatch: 2});
+
 
   // useEffect(() => {
   //   const changeScreenOrientation = async () => {
@@ -30,17 +28,9 @@ export default function App() {
   // }  {...{setScoutName}}
 
 
-  const handleScoutNameChange = (newScoutName) => {
-    setScoutName(newScoutName);
-  }
-
-  const handleMatchChange = (newMatchNumber, newTeamNumber) => {
-    setCurrentTeam(newTeamNumber);
-    setMatchNumber(newMatchNumber);
-  }
-
   // Default view when opening up the app.  Maybe future will open to Setup if match, teams, tablet are not set.
-  const [content, setContent] = useState(<MatchSetup currentScoutName={scoutName} currentMatchNumber={matchNumber} onScoutNameChange={handleScoutNameChange} onMatchChange={handleMatchChange} />);
+  const [selectedContent, setSelectedContent] = useState('MatchSelect');
+  const [content, setContent] = useState(<MatchSetup appData={appData} setAppData={setAppData} />);
 
   return (
     <View style={{padding: 0, flex: 1}}>
@@ -48,7 +38,7 @@ export default function App() {
         <View style={{flex: 2, flexDirection: 'row'}}>
           <Ionicons name="eye" size={22} color="white" />
           <Text style={[styles.title, {paddingRight: 20}]}> TFT Scouter</Text>
-          <Text style={[styles.title, scoutLocation[0] === 'B' ? styles.teamBlue : styles.teamRed]}>{scoutLocation}</Text></View>
+          <Text style={[styles.title, appData.scountLocation[0] === 'B' ? styles.teamBlue : styles.teamRed]}>{appData.scountLocation}</Text></View>
         <View style={{flex: 4, flexDirection: 'row-reverse'}}>
           <TouchableOpacity
               activeOpacity={0.5}
@@ -56,7 +46,7 @@ export default function App() {
               onPress={() => {setContent(<AppSettings />); setSelectedContent('AppSettings');}}>
               <Ionicons name="menu" size={32} color="white" />
           </TouchableOpacity>
-          <Text style={[styles.title, {paddingRight: 10}]}>Match: {matchNumber} | Team: {currentTeam} | {scoutName}</Text>
+          <Text style={[styles.title, {paddingRight: 10}]}>Match: {appData.currentMatch} | Team: {appData.currentTeam} | {appData.currentScout}</Text>
         </View>
       </View>
       <View style={styles.container}>
@@ -64,7 +54,7 @@ export default function App() {
           <TouchableOpacity
             activeOpacity={0.5}
             key="MatchSelect"
-            onPress={() => {setContent(<MatchSetup currentScoutName={scoutName} currentMatchNumber={matchNumber}  onScoutNameChange={handleScoutNameChange} onMatchChange={handleMatchChange} />); setSelectedContent('MatchSelect');}}
+            onPress={() => {setContent(<MatchSetup appData={appData} setAppData={setAppData} />); setSelectedContent('MatchSelect');}}
             style={[styles.button, selectedContent === 'MatchSelect' && styles.selectedContent]}>
             <Text style={[styles.buttonLabel, selectedContent === 'MatchSelect' && styles.selectedLabel]}>Match{"\n"}Select</Text>
           </TouchableOpacity>


### PR DESCRIPTION
Per #75 
Determined that Context API, Redux, or Mobx are not needed for our current app structure at this time.  Direction moving forward is to group common data elements into a single useState structure using `prevAppData => ({...prevAppData, key: value, key: value})`, ensuring the "global" data is being updated.

See appData and how Match Select view gets it and updates the "global" data structure by prop drilling.