### PR TITLE
Update Auto background color to match its button

### DIFF
--- a/ToasterScout/app/Auto.js
+++ b/ToasterScout/app/Auto.js
@@ -473,8 +473,8 @@ const Auto = ({
           width: 906,
           height: 508,
           position: 'absolute',
-          backgroundColor: 'black',
-          // backgroundColor: 'olive',
+          // backgroundColor: 'black',
+          backgroundColor: 'olive',
         },
       ]}>
     </View>


### PR DESCRIPTION
This pull request includes a small change to the `ToasterScout/app/Auto.js` file. The change updates the `backgroundColor` property from 'black' to 'olive' and comments out the previous 'black' background color setting.

* [`ToasterScout/app/Auto.js`](diffhunk://#diff-0d2b53f9662ef4da0f22c1cb01d47d718a1d82b9aa01f871827fe70b1cbaa1aaL476-R477): Updated the `backgroundColor` property to 'olive' and commented out the previous 'black' background color setting.