### PR TITLE
Quick fix of the eventdetail View and the useEffect for auto leave.

### DIFF
--- a/ToasterScout/app/Auto.js
+++ b/ToasterScout/app/Auto.js
@@ -114,7 +114,7 @@ const Auto = ({
 
   useEffect(() => {
     setGameData(prevGameData => ({...prevGameData, aL:leave}))
-  })
+  }, [leave]);
 
   // Scoring functions
 

--- a/client/src/views/Events/Eventdetail.js
+++ b/client/src/views/Events/Eventdetail.js
@@ -98,9 +98,9 @@ const Eventdetail = () => {
                         // },
                     }}
                     slots={{
-                        0: (data) => {
+                        0: (data, row) => {
                             return (
-                                <div onClick={() => handleViewItem(`/matchdetails/?matchId=${data}`)}><OverlayTrigger placement="top" overlay={renderTooltip({ text: 'View Match' })}><MdOutlinePreview size='2em' /></OverlayTrigger></div>
+                                <div onClick={() => handleViewItem(`/matchdetails/?matchId=${row.id}`)}><OverlayTrigger placement="top" overlay={renderTooltip({ text: 'View Match' })}><MdOutlinePreview size='2em' /></OverlayTrigger></div>
                             );
                         },
                     }}


### PR DESCRIPTION
This pull request includes changes to two files to fix dependencies and improve functionality. The most important changes include adding a dependency array to the `useEffect` hook in `Auto.js` and modifying the `slots` function parameters in `Eventdetail.js`.

Dependency fixes:

* [`ToasterScout/app/Auto.js`](diffhunk://#diff-0d2b53f9662ef4da0f22c1cb01d47d718a1d82b9aa01f871827fe70b1cbaa1aaL117-R117): Added `leave` as a dependency in the `useEffect` hook to ensure the effect runs correctly when `leave` changes.

Functionality improvements:

* [`client/src/views/Events/Eventdetail.js`](diffhunk://#diff-8c91b1a537f04787d07d9739aa6ed614ba88eb79923bfba55e4d44977afb4266L101-R103): Modified the `slots` function to include `row` as a parameter and updated the `handleViewItem` function to use `row.id` instead of `data` for better accuracy.