### PR TITLE
When added matches manually on ScoutDB, use the entered match type instead of just qm

### DIFF
--- a/client/src/views/Events/Eventdetail.js
+++ b/client/src/views/Events/Eventdetail.js
@@ -223,7 +223,7 @@ const Eventdetail = () => {
                     blueThreeTeamNumber: newMatch.blueThree,
                     redRankingPoint: 0,
                     blueRankingPoint: 0,
-                    matchKey: appData.currentEventKey + '_qm' + newMatch.matchNumber,
+                    matchKey: appData.currentEventKey + '_' + newMatch.matchType + newMatch.matchNumber,
                     event_id: appData.currentEventID,
                 },
                 { headers: { 'Content-Type': 'application/json' } }


### PR DESCRIPTION
Fixing #188 
Fixed the hardcoded qm (qualify Match) with what is entered in he mtchType when added.

This pull request includes a small change to the `Eventdetail` component in the `client/src/views/Events/Eventdetail.js` file. The change modifies the `matchKey` to include the match type in addition to the match number.

* [`client/src/views/Events/Eventdetail.js`](diffhunk://#diff-8c91b1a537f04787d07d9739aa6ed614ba88eb79923bfba55e4d44977afb4266L226-R226): Changed the `matchKey` to concatenate `appData.currentEventKey`, `newMatch.matchType`, and `newMatch.matchNumber` instead of just `appData.currentEventKey` and `newMatch.matchNumber`.