### PR TITLE
Match Note Picklist updates

### DIFF
--- a/ToasterScout/app/PostMatch.js
+++ b/ToasterScout/app/PostMatch.js
@@ -133,7 +133,7 @@ const [info4Toggled, setInfo4Toggled] = useState(tempinfo.includes('4'));
           style={[styles.buttonAuto, info4Toggled && styles.selected,]} 
           onPress={() => setInfo4Toggled(!info4Toggled)}>
           <Text style={styles.contentText}>
-            No Robot On Field
+            No Robot on Field
           </Text>
         </Pressable>
       </View>

--- a/ToasterScout/app/PostMatch.js
+++ b/ToasterScout/app/PostMatch.js
@@ -16,26 +16,15 @@ console.log(tempinfo);
 const [info1Toggled, setInfo1Toggled] = useState(tempinfo.includes('1'));
 const [info2Toggled, setInfo2Toggled] = useState(tempinfo.includes('2'));
 const [info3Toggled, setInfo3Toggled] = useState(tempinfo.includes('3'));
+const [info4Toggled, setInfo4Toggled] = useState(tempinfo.includes('4'));
 
-const infoToggled1 = () => {
-  setInfo1Toggled(!info1Toggled);
-  console.log(info1Toggled);
-};
-
-const infoToggled2 = () => {
-  setInfo2Toggled(!info2Toggled);
-};
-
-const infoToggled3 = () => {
-  setInfo3Toggled(!info3Toggled);
-};
 
 // *** Update gameData when Post Match data has changed ***
   useEffect(() => {
       setGameData(prevGameData => ({...prevGameData, bzl: displayClimbSelect}));
-      var tempGameData = (info1Toggled ? '1,': '') + (info2Toggled ? '2,' : '') + (info3Toggled ? '3,' : '');//`${info1Toggled},${info2Toggled},${info3Toggled}`;
+      var tempGameData = (info1Toggled ? '1,': '') + (info2Toggled ? '2,' : '') + (info3Toggled ? '3,' : '') + (info4Toggled ? '4,' : '');//`${info1Toggled},${info2Toggled},${info3Toggled}`;
         setGameData(prevGameData => ({...prevGameData, snp: tempGameData}));
-  }, [displayClimbSelect, info1Toggled, info2Toggled, info3Toggled]);
+  }, [displayClimbSelect, info1Toggled, info2Toggled, info3Toggled, info4Toggled]);
 
 
 
@@ -121,23 +110,30 @@ const infoToggled3 = () => {
           <Text style={[styles.title, {textAlign: 'center'}]}>Match Notes Picklist</Text>
         <Pressable 
           style={[styles.buttonAuto, info1Toggled && styles.selected,]} 
-          onPress={infoToggled1}>
+          onPress={() => setInfo1Toggled(!info1Toggled)}>
           <Text style={styles.contentText}>
             Preformed Defense
           </Text>
         </Pressable>
         <Pressable
           style={[styles.buttonAuto, info2Toggled && styles.selected,]} 
-          onPress={infoToggled2}>
+          onPress={() => setInfo2Toggled(!info2Toggled)}>
           <Text style={styles.contentText}>
             Stopped Mid-Match
           </Text>
         </Pressable>
-        <Pressable
+        {/* <Pressable
           style={[styles.buttonAuto, info3Toggled && styles.selected,]} 
-          onPress={infoToggled3}>
+          onPress={() => setInfo3Toggled(!info3Toggled)}>
           <Text style={styles.contentText}>
             No Auto
+          </Text>
+        </Pressable> */}
+        <Pressable
+          style={[styles.buttonAuto, info4Toggled && styles.selected,]} 
+          onPress={() => setInfo4Toggled(!info4Toggled)}>
+          <Text style={styles.contentText}>
+            No Robot On Field
           </Text>
         </Pressable>
       </View>


### PR DESCRIPTION
- Added 'No Robot on Field'
- Removed ' No Auton'

This pull request includes changes to the `ToasterScout/app/PostMatch.js` file to add a new toggle option and simplify the code for handling toggle states.

Key changes:

* Added a new toggle state for `info4Toggled` to handle an additional option in the post-match data.
* Updated the `useEffect` hook to include the new `info4Toggled` state in the `tempGameData` string and dependency array.
* Removed individual toggle functions (`infoToggled1`, `infoToggled2`, `infoToggled3`) and replaced them with inline functions directly in the `onPress` handlers of the `Pressable` components.
* Commented out the `Pressable` component for `info3Toggled` and added a new `Pressable` component for `info4Toggled` with the corresponding text and toggle state.
